### PR TITLE
Expose `getCurrentPageId` function

### DIFF
--- a/README.md
+++ b/README.md
@@ -694,6 +694,7 @@ Here is an example function that makes the "Vintage blaster" item to appear with
 Here is a recap of all the functions that you can use in writing your games:
 
 * `story.currentPageIs()`
+* `story.getCurrentPageId()`
 * `story.removeFromInventory()`
 * `story.putInInventory()`
 * `story.isInInventory()`
@@ -708,7 +709,7 @@ Here is a recap of all the functions that you can use in writing your games:
 * `story.disable()`
 * `story.endGame()`
 
-The only one we didn't encounter in our tutorial is `story.currentPageIs()`, but its usage is as useful as banal: `story.currentPageIs(<ID_OF_A_PAGE>)` and returns true or false based on the page currently being visualized.
+The only ones we haven't encountered in our tutorial are `story.currentPageIs()` and `story.getCurrentPageId()`, but their usage is as useful as banal: `story.currentPageIs(<ID_OF_A_PAGE>)` and returns true or false based on the page currently being visualized, while `story.getCurrentPageId()` returns the ID of the current page.
 
 This is it. Dedalus is a powerful tool to express your creativity and with it open integration with HTML, CSS and Javascript, the possibilities to customize and extend it to suit the needs of your sories are endless.
 

--- a/src/dedalus.js
+++ b/src/dedalus.js
@@ -368,6 +368,7 @@ var Dedalus,
     Dedalus.prototype.generateEmptyStory = function () {
         return {
             currentPageIs                : this.currentPageIs.bind(this),
+            getCurrentPageId             : this.getCurrentPageId.bind(this),
             removeFromInventory          : this.removeFromInventory.bind(this),
             putInInventory               : this.putInInventory.bind(this),
             isInInventory                : this.isInInventory.bind(this),


### PR DESCRIPTION
This PR simply adds access to the pre-existing function `getCurrentPageId` to the public `story` interface.

Access to this function was useful to me so I could make a hash mapping page ID -> JS and call it from `<afterEveryPageTurn>` so that I can organize all the page-specific JS in a separate file instead of inside each `<page>` object.